### PR TITLE
Modified admin: boolean column with role: enum and integrated isAdmin…

### DIFF
--- a/database/schema.prisma
+++ b/database/schema.prisma
@@ -8,6 +8,12 @@ datasource db {
   provider = "postgresql"
 }
 
+enum Role {
+  STUDENT
+  STAFF
+  ADMIN
+}
+
 // User model for authentication and profiles
 model User {
   id            String     @id @default(cuid())
@@ -19,7 +25,7 @@ model User {
   about         String?
   pronouns      String?
   link          String?
-  admin         Boolean    @default(false)
+  role          Role      @default(STUDENT)  
   presentations Presentation[]
   productions   Production[]
   semesters     Semester[]

--- a/database/seed.ts
+++ b/database/seed.ts
@@ -63,7 +63,7 @@ async function main() {
     data: {
       name: adminName,
       email: adminEmail,
-      admin: true,
+      role: "ADMIN",
     },
   });
 

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from '@prisma/config';
+import * as dotenv from 'dotenv';
+dotenv.config();
 
 // Prisma configuration for schema location, database connection, and seeding
 export default defineConfig({

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -16,7 +16,7 @@ export async function getAuthSession() {
 	return {
 		session,
 		user: session?.user ?? null,
-		isAdmin: session?.user?.admin ?? false,
+		isAdmin: session?.user?.role === "ADMIN"
 	};
 }
 

--- a/src/actions/productions.ts
+++ b/src/actions/productions.ts
@@ -14,10 +14,10 @@ export async function getProduction(id: string) {
 		const production = await prisma.production.findUnique({
 			where: { id: id },
 			include: { 
-				producers: { select: { id: true, name: true, image: true, admin: true } }, 
+				producers: { select: { id: true, name: true, image: true, role: true } }, 
 				presentations: { 
 					include: { 
-						presenters: { select: { id: true, name: true, image: true, admin: true } } 
+						presenters: { select: { id: true, name: true, image: true, role: true } } 
 					} 
 				}, 
 				thursday: true 

--- a/src/actions/semesters.ts
+++ b/src/actions/semesters.ts
@@ -82,7 +82,7 @@ export async function getSemesterFromName(name?: string) {
 										name: true,
 										about: true,
 										presenters: {
-											select: { id: true, name: true, image: true, admin: true }
+											select: { id: true, name: true, image: true, role: true }
 										} 
 									} 
 								} 
@@ -124,7 +124,7 @@ export async function getAdminSemesterData(semesterId: string, rawFilters: any =
 										id: true,
 										name: true,
 										presenters: {
-											select: { id: true, name: true, image: true, admin: true }
+											select: { id: true, name: true, image: true, role: true }
 										}
 									},
 								},
@@ -148,6 +148,7 @@ export async function getAdminSemesterData(semesterId: string, rawFilters: any =
 			where: {
 				semesters: { some: { id: semesterId } },
 				name: { contains: userSearch, mode: "insensitive" },
+				role: { not: "STAFF" },
 			},
 			orderBy: { name: "asc" },
 			select: {

--- a/src/actions/thursdays.ts
+++ b/src/actions/thursdays.ts
@@ -29,14 +29,14 @@ export async function getThursday(id: string) {
 						name: true,
 						location: true,
 						thursday_id: true,
-						producers: { select: { id: true, name: true, image: true, admin: true } },
+						producers: { select: { id: true, name: true, image: true, role: true } },
 						presentations: {
 							select: {
 								id: true,
 								name: true,
 								about: true,
 								production_id: true,
-								presenters: { select: { id: true, name: true, image: true, admin: true } }
+								presenters: { select: { id: true, name: true, image: true, role: true } }
 							}
 						}
 					}
@@ -134,14 +134,14 @@ export async function getFilteredThursdays(rawFilters: { semester?: string | str
 						name: true,
 						location: true,
 						thursday_id: true,
-						producers: { select: { id: true, name: true, image: true, admin: true } },
+						producers: { select: { id: true, name: true, image: true, role: true } },
 						presentations: {
 							select: {
 								id: true,
 								name: true,
 								about: true,
 								production_id: true,
-								presenters: { select: { id: true, name: true, image: true, admin: true } }
+								presenters: { select: { id: true, name: true, image: true, role: true } }
 							}
 						}
 					},

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -25,7 +25,7 @@ export async function getUser(id: string) {
 				pronouns: true,
 				link: true,
 				about: true,
-				admin: true,
+				role: true,
 				semesters: {
 					select: { id: true, name: true }
 				},
@@ -55,13 +55,13 @@ export async function getUser(id: string) {
 export async function getAllUsers() {
 	return await action(async () => {
 		return await prisma.user.findMany({
+			where: { role: { not: "STAFF" } },
 			select: {
 				id: true,
 				name: true,
 				email: true,
 				image: true,
-				admin: true,
-				// Removed productions and semesters as they are not needed for user selection lists
+				role: true,
 			},
 			orderBy: { name: "asc" }
 		});
@@ -110,7 +110,7 @@ export async function getFilteredUsers(rawFilters: any) {
 				id: true,
 				name: true,
 				image: true,
-				admin: true,
+				role: true,
 			},
 		});
 	});
@@ -123,7 +123,7 @@ export async function editUser(formData: UserInput) {
 			throw new Error(validation.error.issues[0].message);
 		}
 		const validatedFields = validation.data;
-		const { id, name, about, image, email, link, pronouns, admin, semesterIds } = validatedFields;
+		const { id, name, about, image, email, link, pronouns, role, semesterIds } = validatedFields;
 		
 		const { user: currentUser, isAdmin } = await getAuthSession();
 		
@@ -135,7 +135,7 @@ export async function editUser(formData: UserInput) {
 		// Only admins can change admin status or semesters
 		const data: Prisma.UserUpdateInput = { name, about, image, link, pronouns, email };
 		if (isAdmin) {
-			data.admin = admin;
+			data.role = role;
 			if (semesterIds) {
 				data.semesters = {
 					set: semesterIds.map(id => ({ id }))

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,7 +2,7 @@ import { auth } from "@/authentication";
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
 	const session = await auth();
-	const isAdmin = session?.user?.admin ?? false;
+	const isAdmin = session?.user?.role === "ADMIN";
 
 	if (isAdmin) {
 		return <>{children}</>;

--- a/src/app/thursdays/page.tsx
+++ b/src/app/thursdays/page.tsx
@@ -44,7 +44,7 @@ export default async function Thursdays({ searchParams }: ThursdaysProps) {
   const semestersResult = await getAllSemesters();
   const semesters = semestersResult.success ? semestersResult.data : [];
   const session = await auth();
-  const isAdmin = session?.user?.admin ?? false;
+  const isAdmin = session?.user?.role === "ADMIN";
 
   const semesterIdParam = Array.isArray(filters.semesterId)
     ? filters.semesterId[0]

--- a/src/app/users/[id]/edit/page.tsx
+++ b/src/app/users/[id]/edit/page.tsx
@@ -28,7 +28,7 @@ export default async function EditUser({ params }: EditUserProps) {
   const currentUser = await getCurrentUser();
   if (!currentUser) return null;
   const session = await auth();
-  const isAdmin = session?.user?.admin ?? false;
+  const isAdmin = session?.user?.role === "ADMIN";
   const semesters = await getAllSemesters();
 
   async function onSubmitEditUser(data: any) {

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -55,13 +55,12 @@ export default async function User({ params }: UserProps) {
         />
 
         <div className={styles.UserData}>
-          {user.admin ? (
-            <div className={styles.DataRow}>
-              <div className={styles.Label} style={{ color: "#f26419" }}>
-                Admin
-              </div>
+          <div className={styles.DataRow}>
+            <div className={styles.Label}>Role</div>
+            <div className={styles.Value}>
+              {user.role.charAt(0) + user.role.slice(1).toLowerCase()}
             </div>
-          ) : null}
+          </div>
 
           <div className={styles.DataRow}>
             <div className={styles.Label}>Pronouns</div>

--- a/src/app/users/add/page.tsx
+++ b/src/app/users/add/page.tsx
@@ -6,7 +6,7 @@ import { auth } from "@/authentication";
 
 export default async function AddUser() {
 	const session = await auth();
-	const isAdmin = session?.user?.admin ?? false;
+	const isAdmin = session?.user?.role === "ADMIN";
 	const semesters = await getAllSemesters();
 	
 	async function onSubmitAddUser(data: any) {

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -36,7 +36,7 @@ export default async function UsersPage({ searchParams }: UsersProps) {
 	const semestersResult = await getAllSemesters();
 	const semesters = semestersResult.success ? semestersResult.data : [];
 	const session = await auth();
-	const isAdmin = session?.user?.admin ?? false;
+	const isAdmin = session?.user?.role === "ADMIN";
 	
 	const semesterIdParam = Array.isArray(filters.semesterId) ? filters.semesterId[0] : filters.semesterId;
 	const semesterParam = Array.isArray(filters.semester) ? filters.semester[0] : filters.semester;

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -5,6 +5,7 @@ import { PrismaAdapter } from "@auth/prisma-adapter";
 
 import { prisma } from "@/database";
 
+
 // Configure and export NextAuth utilities for authentication
 export const { handlers, signIn, signOut, auth } = NextAuth({
   trustHost: true,
@@ -67,13 +68,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           where: { email: token.email },
           select: {
             id: true,
-            admin: true,
+            role: true,
           },
         });
 
         if (dbUser) {
           token.id = dbUser.id;
-          token.admin = dbUser.admin;
+          token.role = dbUser.role;
         } else {
           return null;
         }
@@ -90,7 +91,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         email: token.email as string,
         name: token.name as string,
         picture: isBase64Image ? "/face.jpg" : picture,
-        admin: token.admin as boolean,
+        role: token.role as string,
       } as any;
     },
 
@@ -98,7 +99,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async session({ session, token }) {
       if (session?.user && token) {
         session.user.id = token.id as string;
-        session.user.admin = token.admin as boolean;
+        session.user.role = token.role as string;
         session.user.name = token.name as string;
         session.user.image = token.picture as string;
       }

--- a/src/components/domain/thursdays/ProductionCard.tsx
+++ b/src/components/domain/thursdays/ProductionCard.tsx
@@ -15,10 +15,10 @@ export default async function ProductionCard({
   isAdmin = false,
 }: ProductionCardProps) {
   const producers = production.producers.filter(
-    (user: any) => user.admin === false,
+    (user: any) => user.role === "ADMIN" === false,
   );
   const faculty = production.producers.filter(
-    (user: any) => user.admin === true,
+    (user: any) => user.role === "ADMIN" === true,
   );
   return (
     <div className={styles.ProductionCard}>

--- a/src/components/domain/thursdays/ThursdayCard.tsx
+++ b/src/components/domain/thursdays/ThursdayCard.tsx
@@ -35,7 +35,7 @@ export default async function ThursdayCard({
   let isAdmin = initialIsAdmin;
   if (isAdmin === undefined) {
     const session = await auth();
-    isAdmin = session?.user?.admin ?? false;
+    isAdmin = session?.user?.role === "ADMIN";
   }
 
   return (

--- a/src/components/domain/users/UserCard.module.css
+++ b/src/components/domain/users/UserCard.module.css
@@ -16,7 +16,13 @@
 .name {
   text-align: center;
   font-weight: bolder;
-  font-size: 1rem; /* your own font size */
+  font-size: 1rem;
+}
+
+.role {
+  text-align: center;
+  font-size: 0.75rem;
+  color: #666;
 }
 
 .UserCard {

--- a/src/components/domain/users/UserCard.tsx
+++ b/src/components/domain/users/UserCard.tsx
@@ -6,7 +6,7 @@ import { normalizeFaceImagePath } from "@/helpers";
 import { User } from "@prisma/client";
 
 interface UserCardProps {
-  user: Pick<User, "id" | "name" | "image" | "admin">;
+  user: Pick<User, "id" | "name" | "image" | "role">;
 }
 
 export default function UserCard({ user }: UserCardProps) {
@@ -14,7 +14,7 @@ export default function UserCard({ user }: UserCardProps) {
     <Block
       as="a"
       href={`/users/${user.id}`}
-      className={`${user.admin ? styles.UserCardAdmin : styles.UserCard} neo-pressable`}
+      className={`${user.role === "ADMIN" ? styles.UserCardAdmin : styles.UserCard} neo-pressable`}
     >
       <div className={`${styles.faceContent}`}>
         <div className={styles.imageWrapper}>
@@ -30,6 +30,7 @@ export default function UserCard({ user }: UserCardProps) {
           />
         </div>
         <div className={styles.name}>{user.name}</div>
+        <div className={styles.role}>{user.role.charAt(0) + user.role.slice(1).toLowerCase()}</div>
       </div>
     </Block>
   );

--- a/src/components/forms/schemas.ts
+++ b/src/components/forms/schemas.ts
@@ -8,7 +8,7 @@ export const UserSchema = z.object({
 	pronouns: z.string().optional(),
 	link: z.string().url("Invalid URL").or(z.literal("")).optional(),
 	about: z.string().optional(),
-	admin: z.boolean().default(false),
+	role: z.enum(["STUDENT", "STAFF", "ADMIN"]).default("STUDENT"),
 	semesterIds: z.array(z.string()).optional().default([]),
 });
 

--- a/src/components/forms/user/UserForm.tsx
+++ b/src/components/forms/user/UserForm.tsx
@@ -6,7 +6,7 @@ import { Space, Typography } from "antd";
 import {
   Input,
   TextArea,
-  Switch,
+  Select,
   Card,
   Button,
   Alert,
@@ -42,7 +42,7 @@ export default function UserForm({
     email: "",
     link: "",
     about: "",
-    admin: false,
+    role: "STUDENT",
     semesterIds: allSemesters.length > 0 ? [allSemesters[0].id] : [],
   };
 
@@ -104,13 +104,21 @@ export default function UserForm({
           </div>
 
           {isCurrentUserAdmin && (
-            <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-              <Text strong>Admin Status</Text>
+            <div>
+              <Text strong style={{ display: "block", marginBottom: "8px" }}>Role</Text>
               <Controller
                 control={control}
-                name="admin"
+                name="role"
                 render={({ field }) => (
-                  <Switch checked={field.value} onChange={field.onChange} />
+                  <Select
+                    {...field}
+                    style={{ width: "100%" }}
+                    options={[
+                      { value: "STUDENT", label: "Student" },
+                      { value: "STAFF", label: "Staff" },
+                      { value: "ADMIN", label: "Admin" },
+                    ]}
+                  />
                 )}
               />
             </div>

--- a/src/components/forms/user/user.transformers.ts
+++ b/src/components/forms/user/user.transformers.ts
@@ -10,7 +10,7 @@ export const transformUserFromAPI = (user: any): UserInput | null => {
     email: user.email,
     link: user.link || "",
     about: user.about || "",
-    admin: user.admin || false,
+    role: user.role || "STUDENT",
     semesterIds: user.semesters?.map((s: any) => s.id) || [],
   };
 };

--- a/src/components/layout/AdminOnly.tsx
+++ b/src/components/layout/AdminOnly.tsx
@@ -7,7 +7,7 @@ interface AdminOnlyProps {
 
 export default async function AdminOnly({ children, fallback = null }: AdminOnlyProps) {
 	const session = await auth();
-	const isAdmin = session?.user?.admin ?? false;
+	const isAdmin = session?.user?.role === "ADMIN";
 
 	if (!isAdmin) {
 		return <>{fallback}</>;

--- a/src/components/layout/NavBar/index.tsx
+++ b/src/components/layout/NavBar/index.tsx
@@ -47,7 +47,7 @@ export default async function NavBar({ session: initialSession }: NavBarProps) {
 					<NavSelect
 						pages={[
 							...pages.slice(0, 2),
-							...(session.user.admin ? [{ href: "/admin", label: "Admin" }] : []),
+							...(session.user.role === "ADMIN" ? [{ href: "/admin", label: "Admin" }] : []),
 							...pages.slice(2),
 						]}
 					/>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 // Middleware to handle authentication, authorization, and route protection
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
-  const isAdmin = req.auth?.user?.admin;
+  const isAdmin = req.auth?.user?.role === "ADMIN";
   const { pathname } = req.nextUrl;
 
   // Redirect unauthenticated users to the welcome page

--- a/types.d.ts
+++ b/types.d.ts
@@ -4,18 +4,11 @@ declare module "next-auth" {
 	interface Session {
 		user: {
 			id: string;
-			admin: boolean;
+			role: string;
 		} & DefaultSession["user"];
 	}
 
 	interface User {
-		admin: boolean;
-	}
-}
-
-declare module "next-auth/jwt" {
-	interface JWT {
-		id: string;
-		admin: boolean;
+		role: string;
 	}
 }


### PR DESCRIPTION
Replaced the admin: boolean DB column with a role enum (STUDENT, STAFF, ADMIN). Every place that checked user.admin now checks user.role === "ADMIN" instead. 

Added a STAFF role that has the same privileges as a student but is excluded from semester, Thursday, and admin panel selection lists via Prisma where filters just like Nita asked for. 

Did the UI change where it was a switch UI to a dropdown to select all three roles when creating a new user. 